### PR TITLE
Update user prop with new id key

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ interface Props {
   onWidgetResize?: Function;
   onWidgetUnread?: Function;
   user?: {
-    user_id: string;
+    id: string;
     [key: string]: any;
   };
   data?: {


### PR DESCRIPTION
The AnnounceKit component now uses the `id` key of the user prop in place of `user_id` to uniquely identify users for user tracking