### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "postinstall": "husky install"
+    "prepare": "husky install"
   },
   "repository": "https://github.com/announcekitapp/announcekit-react",
   "homepage": "https://announcekit.app",


### PR DESCRIPTION
postinstall scripts runs after every install. So it runs even when someone consumes this package as a dependency. changing it to "prepare" to make sure it runs only during development time.