### PR TITLE
Declare the label prop as an array instead of a tuple

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ interface Props {
   onWidgetOpen?: Function;
   onWidgetClose?: Function;
   onWidgetResize?: Function;
-  labels?: [string];
+  labels?: string[];
   userToken?: string;
 
   onWidgetUnread?: Function;


### PR DESCRIPTION
It prevented me to pass filter labels since the tuple required the array to have a single element.