### PR TITLE
Update readme.md with v2->v3 section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,3 +88,9 @@ function App() {
     )
 }
 ```
+
+## Upgrading from v2 to v3
+
+# Breaking Changes
+
+`catchClick` prop has been removed and replaced with the new ref API '.open()' method


### PR DESCRIPTION
Hey guys,

I've recently upgraded this package in my repo from v2 and v3 and was sorely missing the breaking change of removal of the `catchClick` prop replaced by the ref API.

Would be great if you added it to either the `readme` or a v3 release notes